### PR TITLE
feat/gripper timeout

### DIFF
--- a/gripper_17.X/nbproject/Makefile-genesis.properties
+++ b/gripper_17.X/nbproject/Makefile-genesis.properties
@@ -1,13 +1,13 @@
 #
-#Sun Mar 02 16:06:56 CET 2025
-default.languagetoolchain.version=4.45
+#Sat Apr 12 11:54:19 CEST 2025
+default.languagetoolchain.version=4.50
 default.Pack.dfplocation=/opt/microchip/mplabx/v6.20/packs/Microchip/SAMC21_DFP/3.8.119
 default.com-microchip-mplab-mdbcore-AtmelIceScripting-AtmelIceScriptingBase.md5=d43f5c951d9688e0858d181444d084d4
 conf.ids=default
-default.languagetoolchain.dir=/opt/microchip/xc32/v4.45/bin
+default.languagetoolchain.dir=/opt/microchip/xc32/v4.50/bin
 default.com-microchip-mplab-nbide-toolchain-xc32-XC32LanguageToolchain.md5=1eaf555a844840d91945cb14109201c3
-host.id=2jbv-wc6h-6s
-configurations-xml=f3a6f29925665d06dbd553a19806248c
+host.id=1ajf-v1xd-vo
+configurations-xml=23f73d9a4da031c6c737553dbdf8a21b
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=f612087c95360c842296d189edfe3321
 proj.dir=/home/nathaniel/vortex-auv-embedded/gripper_17.X
 host.platform=linux

--- a/gripper_17.X/nbproject/Makefile-local-default.mk
+++ b/gripper_17.X/nbproject/Makefile-local-default.mk
@@ -20,18 +20,18 @@ PATH:=/opt/microchip/mplabx/v6.20/mplab_platform/platform/../mplab_ide/modules/.
 # Path to java used to run MPLAB X when this makefile was created
 MP_JAVA_PATH="/opt/microchip/mplabx/v6.20/sys/java/zulu8.64.0.19-ca-fx-jre8.0.345-linux_x64/bin/"
 OS_CURRENT="$(shell uname -s)"
-MP_CC="/opt/microchip/xc32/v4.45/bin/xc32-gcc"
-MP_CPPC="/opt/microchip/xc32/v4.45/bin/xc32-g++"
+MP_CC="/opt/microchip/xc32/v4.50/bin/xc32-gcc"
+MP_CPPC="/opt/microchip/xc32/v4.50/bin/xc32-g++"
 # MP_BC is not defined
-MP_AS="/opt/microchip/xc32/v4.45/bin/xc32-as"
-MP_LD="/opt/microchip/xc32/v4.45/bin/xc32-ld"
-MP_AR="/opt/microchip/xc32/v4.45/bin/xc32-ar"
+MP_AS="/opt/microchip/xc32/v4.50/bin/xc32-as"
+MP_LD="/opt/microchip/xc32/v4.50/bin/xc32-ld"
+MP_AR="/opt/microchip/xc32/v4.50/bin/xc32-ar"
 DEP_GEN=${MP_JAVA_PATH}java -jar "/opt/microchip/mplabx/v6.20/mplab_platform/platform/../mplab_ide/modules/../../bin/extractobjectdependencies.jar"
-MP_CC_DIR="/opt/microchip/xc32/v4.45/bin"
-MP_CPPC_DIR="/opt/microchip/xc32/v4.45/bin"
+MP_CC_DIR="/opt/microchip/xc32/v4.50/bin"
+MP_CPPC_DIR="/opt/microchip/xc32/v4.50/bin"
 # MP_BC_DIR is not defined
-MP_AS_DIR="/opt/microchip/xc32/v4.45/bin"
-MP_LD_DIR="/opt/microchip/xc32/v4.45/bin"
-MP_AR_DIR="/opt/microchip/xc32/v4.45/bin"
+MP_AS_DIR="/opt/microchip/xc32/v4.50/bin"
+MP_LD_DIR="/opt/microchip/xc32/v4.50/bin"
+MP_AR_DIR="/opt/microchip/xc32/v4.50/bin"
 CMSIS_DIR=/opt/microchip/mplabx/v6.20/packs/arm/CMSIS/5.4.0
 DFP_DIR=/opt/microchip/mplabx/v6.20/packs/Microchip/SAMC21_DFP/3.8.119

--- a/gripper_17.X/nbproject/configurations.xml
+++ b/gripper_17.X/nbproject/configurations.xml
@@ -63,7 +63,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>AtmelIceTool</platformTool>
         <languageToolchain>XC32</languageToolchain>
-        <languageToolchainVersion>4.45</languageToolchainVersion>
+        <languageToolchainVersion>4.50</languageToolchainVersion>
         <platform>2</platform>
       </toolsSet>
       <packs>

--- a/gripper_17.X/nbproject/private/configurations.xml
+++ b/gripper_17.X/nbproject/private/configurations.xml
@@ -5,7 +5,7 @@
   <confs>
     <conf name="default" type="2">
       <platformToolSN>:=MPLABComm-USB-Microchip:=&lt;vid>03EB:=&lt;pid>2141:=&lt;rev>0101:=&lt;man>Atmel Corp.:=&lt;prod>Atmel-ICE CMSIS-DAP:=&lt;sn>J42700072145:=&lt;drv>x:=&lt;xpt>h:=end</platformToolSN>
-      <languageToolchainDir>/opt/microchip/xc32/v4.45/bin</languageToolchainDir>
+      <languageToolchainDir>/opt/microchip/xc32/v4.50/bin</languageToolchainDir>
       <mdbdebugger version="1">
         <placeholder1>place holder 1</placeholder1>
         <placeholder2>place holder 2</placeholder2>

--- a/gripper_17.X/nbproject/private/private.xml
+++ b/gripper_17.X/nbproject/private/private.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project-private xmlns="http://www.netbeans.org/ns/project-private/1">
+    <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/2" lastBookmarkId="0"/>
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group/>
     </open-files>

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -83,12 +83,9 @@ typedef enum {
 /*CAN*/
 static uint32_t status = 0;
 static uint32_t xferContext = 0;
-/* Variable to save Tx/Rx message */
 static uint32_t messageID = 0x469;
 static uint32_t rx_messageID = 0;
-// static uint8_t message[64] = {0};
 static uint8_t rx_message[64] = {0};
-// static uint8_t messageLength = 0;
 static uint8_t rx_messageLength = 0;
 static uint16_t timestamp = 0;
 static CAN_MSG_RX_FRAME_ATTRIBUTE msgFrameAttr = CAN_MSG_RX_DATA_FRAME;
@@ -97,11 +94,10 @@ static CAN_MSG_RX_FRAME_ATTRIBUTE msgFrameAttr = CAN_MSG_RX_DATA_FRAME;
 volatile SERVO_ADC_PINS servo_status = SERVO_1;
 uint32_t myAppObj = 0;
 uint16_t adc_result_array[TRANSFER_SIZE];
-/*float input_voltage;*/
 
 volatile static STATES gripper_state = STATE_IDLE;
-
 static uint8_t encoder_angles[7] = {0};
+
 
 static uint8_t encoder_read(uint8_t* data, uint8_t reg);
 static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds);
@@ -270,8 +266,6 @@ bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
 
         case SERCOM_I2C_SLAVE_TRANSFER_EVENT_RX_READY:
 
-            // Encoder_Read(encoder_angles, ENCODER_ADDR,
-            // ANGLE_REGISTER);
             if (dataIndex < sizeof(dataBuffer)) {
                 dataBuffer[dataIndex++] = SERCOM3_I2C_ReadByte();
             }

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -5,23 +5,23 @@
  * Created on January 19, 2025, 2:50 PM
  */
 
-#include "adc0.h"
-#include "can1.h"
-#include "can_common.h"
-#include "clock.h"
-#include "dma.h"
-#include "i2c.h" // I2C client backup
-#include "pm.h"
-#include "rtc.h"
-#include "sam.h"
-#include "samc21e17a.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "adc0.h"
+#include "can1.h"
+#include "can_common.h"
+#include "clock.h"
+#include "dma.h"
+#include "i2c.h"  // I2C client backup
+#include "pm.h"
+#include "rtc.h"
+#include "sam.h"
+#include "samc21e17a.h"
 /*#include "sercom0_i2c.h"*/
-#include "sercom1_i2c.h" // Encoder i2c
+#include "sercom1_i2c.h"  // Encoder i2c
 #include "system_init.h"
 #include "tcc.h"
 #include "tcc0.h"
@@ -39,7 +39,7 @@
 
 #define TRANSFER_SIZE 16
 #define ADC_VREF 5.0f
-#define CURRENT_TRESHOLD 2.7f // 1 A
+#define CURRENT_TRESHOLD 2.7f  // 1 A
 #define VOLTAGE_THRESHOLD 2048
 #define RTC_COMPARE_VAL 50
 
@@ -48,36 +48,36 @@ uint8_t Can0MessageRAM[CAN0_MESSAGE_RAM_CONFIG_SIZE]
 
 /* Application's state machine enum */
 typedef enum {
-  STATE_IDLE,
-  STATE_GRIPPER_ACTIVE,
+    STATE_IDLE,
+    STATE_GRIPPER_ACTIVE,
 } STATES;
 
 typedef enum {
-  STATE_CAN_RECEIVE,
-  STATE_CAN_TRANSMIT,
+    STATE_CAN_RECEIVE,
+    STATE_CAN_TRANSMIT,
 } CAN_STATES;
 
 // CAN FD RECIEVE ID table
 typedef enum {
-  STOP_GRIPPER = 0x469,
-  START_GRIPPER,
-  SET_PWM,
-  RESET_MCU,
+    STOP_GRIPPER = 0x469,
+    START_GRIPPER,
+    SET_PWM,
+    RESET_MCU,
 } CAN_RECEIVE_ID;
 
 // I2C RECIEVE START BYTE table
 typedef enum {
-  I2C_SET_PWM,
-  I2C_STOP_GRIPPER,
-  I2C_START_GRIPPER,
-  I2C_RESET_MCU,
+    I2C_SET_PWM,
+    I2C_STOP_GRIPPER,
+    I2C_START_GRIPPER,
+    I2C_RESET_MCU,
 } I2C_STARTBYTE_ID;
 
 /* Servo pins enum for ADC reading */
 typedef enum {
-  SERVO_1,
-  SERVO_2,
-  SERVO_3,
+    SERVO_1,
+    SERVO_2,
+    SERVO_3,
 } SERVO_ADC_PINS;
 
 /*CAN*/
@@ -98,8 +98,8 @@ uint16_t adc_result_array[TRANSFER_SIZE];
 volatile static STATES gripper_state = STATE_IDLE;
 static uint8_t encoder_angles[7] = {0};
 
-static uint8_t encoder_read(uint8_t *data, uint8_t reg);
-static void set_pwm_dutycycle(uint8_t *dutyCycleMicroSeconds);
+static uint8_t encoder_read(uint8_t* data, uint8_t reg);
+static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds);
 
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle);
@@ -110,403 +110,408 @@ void Dmac_Channel0_Callback(DMAC_TRANSFER_EVENT returned_evnt,
                             uintptr_t MyDmacContext);
 
 int main(void) {
-  NVMCTRL_REGS->NVMCTRL_CTRLB = NVMCTRL_CTRLB_RWS(3);
-  PM_Initialize();
-  PIN_Initialize();
-  CLOCK_Initialize();
-  NVMCTRL_Initialize();
-  TCC1_PWMInitialize();
-  TCC0_PWMInitialize();
-  CAN0_Initialize();
-  // SERCOM0_I2C_Initialize();  // I2C 3
-  SERCOM1_I2C_Initialize(); // I2C 2
+    NVMCTRL_REGS->NVMCTRL_CTRLB = NVMCTRL_CTRLB_RWS(3);
+    PM_Initialize();
+    PIN_Initialize();
+    CLOCK_Initialize();
+    NVMCTRL_Initialize();
+    TCC1_PWMInitialize();
+    TCC0_PWMInitialize();
+    CAN0_Initialize();
+    // SERCOM0_I2C_Initialize();  // I2C 3
+    SERCOM1_I2C_Initialize();  // I2C 2
 
-  SERCOM0_USART_Initialize(); // USART for Debugging
+    SERCOM0_USART_Initialize();  // USART for Debugging
 
-  SERCOM3_SLAVE_I2C_Initialize();
+    SERCOM3_SLAVE_I2C_Initialize();
 
-  EVSYS_Initialize();
-  ADC0_Initialize();
-  DMAC_Initialize();
-  RTC_Initialize();
+    EVSYS_Initialize();
+    ADC0_Initialize();
+    DMAC_Initialize();
+    RTC_Initialize();
 
-  NVIC_Initialize();
+    NVIC_Initialize();
 
-  /* Peripherals should be disabled by default and will be enabled
-   Enable if testing without CAN or I2C */
-  // TCC1_PWMStart();
-  // TCC0_PWMStart();
-  // ADC0_Enable();
-  // RTC_Timer32Start();
-  // RTC_Timer32CompareSet(RTC_COMPARE_VAL);
+    /* Peripherals should be disabled by default and will be enabled
+     Enable if testing without CAN or I2C */
+    // TCC1_PWMStart();
+    // TCC0_PWMStart();
+    // ADC0_Enable();
+    // RTC_Timer32Start();
+    // RTC_Timer32CompareSet(RTC_COMPARE_VAL);
 
-  CAN0_MessageRAMConfigSet(Can0MessageRAM);
+    CAN0_MessageRAMConfigSet(Can0MessageRAM);
 
-  // SERCOM3_I2C_CallbackRegister(SERCOM_I2C_Callback, 0);
+    // SERCOM3_I2C_CallbackRegister(SERCOM_I2C_Callback, 0);
 
-  // TCC0_PWMCallbackRegister(TCC_PeriodEventHandler, (uintptr_t)NULL);
+    // TCC0_PWMCallbackRegister(TCC_PeriodEventHandler, (uintptr_t)NULL);
 
-  DMAC_ChannelCallbackRegister(DMAC_CHANNEL_0, Dmac_Channel0_Callback,
-                               (uintptr_t)&myAppObj);
-  CAN0_RxCallbackRegister(CAN_Recieve_Callback, (uintptr_t)STATE_CAN_RECEIVE,
-                          CAN_MSG_ATTR_RX_FIFO0);
-  CAN0_TxCallbackRegister(CAN_Transmit_Callback, (uintptr_t)STATE_CAN_TRANSMIT);
+    DMAC_ChannelCallbackRegister(DMAC_CHANNEL_0, Dmac_Channel0_Callback,
+                                 (uintptr_t)&myAppObj);
+    CAN0_RxCallbackRegister(CAN_Recieve_Callback, (uintptr_t)STATE_CAN_RECEIVE,
+                            CAN_MSG_ATTR_RX_FIFO0);
+    CAN0_TxCallbackRegister(CAN_Transmit_Callback,
+                            (uintptr_t)STATE_CAN_TRANSMIT);
 
-  memset(rx_message, 0x00, sizeof(rx_message));
-  // Enabling CAN recieve interrupt for fifo0
-  CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message, &timestamp,
-                      CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+    memset(rx_message, 0x00, sizeof(rx_message));
+    // Enabling CAN recieve interrupt for fifo0
+    CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                        &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
 
-  // Servo Enable
-  /*PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);*/
-  /*printf("Initialize complete\n");*/
-  DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
-                       (const void *)adc_result_array,
-                       sizeof(adc_result_array));
-  while (true) {
-    switch (gripper_state) {
-    case STATE_IDLE:
-      PM_IdleModeEnter();
-      break;
-    case STATE_GRIPPER_ACTIVE:
-      break;
-    default:
-      break;
+    // Servo Enable
+    /*PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);*/
+    /*printf("Initialize complete\n");*/
+    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
+                         (const void*)adc_result_array,
+                         sizeof(adc_result_array));
+    while (true) {
+        switch (gripper_state) {
+            case STATE_IDLE:
+                PM_IdleModeEnter();
+                break;
+            case STATE_GRIPPER_ACTIVE:
+                break;
+            default:
+                break;
+        }
     }
-  }
 
-  return EXIT_FAILURE;
+    return EXIT_FAILURE;
 }
 
-static uint8_t encoder_read(uint8_t *data, uint8_t reg) {
-  const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
-                                                   GRIP_ADDR};
-  uint8_t status = 0;
-  uint16_t timeout;
-  uint16_t rawData[NUM_ENCODERS] = {0};
-  uint8_t dataBuffer[2] = {0};
+static uint8_t encoder_read(uint8_t* data, uint8_t reg) {
+    const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
+                                                     GRIP_ADDR};
+    uint8_t status = 0;
+    uint16_t timeout;
+    uint16_t rawData[NUM_ENCODERS] = {0};
+    uint8_t dataBuffer[2] = {0};
 
-  for (uint8_t i; i < NUM_ENCODERS; i++) {
-    if (!SERCOM1_I2C_WriteRead(encoder_addresses[i], &reg, 1, dataBuffer, 2)) {
-      return 1;
+    for (uint8_t i; i < NUM_ENCODERS; i++) {
+        if (!SERCOM1_I2C_WriteRead(encoder_addresses[i], &reg, 1, dataBuffer,
+                                   2)) {
+            return 1;
+        }
+        timeout = I2C_TIMEOUT;
+        while (SERCOM1_I2C_IsBusy()) {
+            if (--timeout == 0) {
+                status |= (1 << i);
+                break;
+            }
+        }
+        rawData[i] = (dataBuffer[0] << 6) | (dataBuffer[1] & 0x3F);
     }
-    timeout = I2C_TIMEOUT;
-    while (SERCOM1_I2C_IsBusy()) {
-      if (--timeout == 0) {
-        status |= (1 << i);
-        break;
-      }
+
+    for (int i = 1; i < NUM_ENCODERS; i++) {
+        data[2 * i] = rawData[i] >> 8;
+        data[2 * i + 1] = rawData[i] & 0xFF;
     }
-    rawData[i] = (dataBuffer[0] << 6) | (dataBuffer[1] & 0x3F);
-  }
+    data[6] = status;
 
-  for (int i = 1; i < NUM_ENCODERS; i++) {
-    data[2 * i] = rawData[i] >> 8;
-    data[2 * i + 1] = rawData[i] & 0xFF;
-  }
-  data[6] = status;
-
-  return 0;
+    return 0;
 }
 
-static void set_pwm_dutycycle(uint8_t *dutyCycleMicroSeconds) {
-  uint16_t shoulderDuty =
-      (dutyCycleMicroSeconds[0] << 8) | dutyCycleMicroSeconds[1];
-  uint16_t wristDuty =
-      (dutyCycleMicroSeconds[2] << 8) | dutyCycleMicroSeconds[3];
-  uint16_t gripDuty =
-      (dutyCycleMicroSeconds[4] << 8) | dutyCycleMicroSeconds[5];
+static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds) {
+    uint16_t shoulderDuty =
+        (dutyCycleMicroSeconds[0] << 8) | dutyCycleMicroSeconds[1];
+    uint16_t wristDuty =
+        (dutyCycleMicroSeconds[2] << 8) | dutyCycleMicroSeconds[3];
+    uint16_t gripDuty =
+        (dutyCycleMicroSeconds[4] << 8) | dutyCycleMicroSeconds[5];
 
-  uint32_t tccValue =
-      (shoulderDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
+    uint32_t tccValue =
+        (shoulderDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
 
-  if (tccValue > PWM_MAX) {
-    TCC0_PWM24bitDutySet(3, PWM_MAX);
-  } else if (tccValue < PWM_MIN) {
-    TCC0_PWM24bitDutySet(3, PWM_MIN);
-  } else {
-    TCC0_PWM24bitDutySet(3, tccValue);
-  }
+    if (tccValue > PWM_MAX) {
+        TCC0_PWM24bitDutySet(3, PWM_MAX);
+    } else if (tccValue < PWM_MIN) {
+        TCC0_PWM24bitDutySet(3, PWM_MIN);
+    } else {
+        TCC0_PWM24bitDutySet(3, tccValue);
+    }
 
-  tccValue = (wristDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
+    tccValue = (wristDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
 
-  if (tccValue > PWM_MAX) {
-    TCC1_PWM24bitDutySet(0, PWM_MAX);
-  } else if (tccValue < PWM_MIN) {
-    TCC1_PWM24bitDutySet(0, PWM_MIN);
-  } else {
-    TCC1_PWM24bitDutySet(0, tccValue);
-  }
+    if (tccValue > PWM_MAX) {
+        TCC1_PWM24bitDutySet(0, PWM_MAX);
+    } else if (tccValue < PWM_MIN) {
+        TCC1_PWM24bitDutySet(0, PWM_MIN);
+    } else {
+        TCC1_PWM24bitDutySet(0, tccValue);
+    }
 
-  tccValue = (gripDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
+    tccValue = (gripDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
 
-  if (tccValue > PWM_MAX) {
-    TCC1_PWM24bitDutySet(1, PWM_MAX);
-  } else if (tccValue < PWM_MIN) {
-    TCC1_PWM24bitDutySet(1, PWM_MIN);
-  } else {
-    TCC1_PWM24bitDutySet(1, tccValue);
-  }
+    if (tccValue > PWM_MAX) {
+        TCC1_PWM24bitDutySet(1, PWM_MAX);
+    } else if (tccValue < PWM_MIN) {
+        TCC1_PWM24bitDutySet(1, PWM_MIN);
+    } else {
+        TCC1_PWM24bitDutySet(1, tccValue);
+    }
 }
 
 static inline void enable_servos() {
-  PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);
+    PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);
 }
 static inline void disable_servos() {
-
-  PORT_REGS->GROUP[0].PORT_OUTCLR = (1 << 0) | (1 << 27) | (1 << 28);
+    PORT_REGS->GROUP[0].PORT_OUTCLR = (1 << 0) | (1 << 27) | (1 << 28);
 }
 
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle) {
-  static uint8_t dataBuffer[7];
-  static uint8_t dataIndex = 0;
+    static uint8_t dataBuffer[7];
+    static uint8_t dataIndex = 0;
 
-  switch (event) {
-  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_ADDR_MATCH:
-    dataIndex = 0;
-    break;
+    switch (event) {
+        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_ADDR_MATCH:
+            dataIndex = 0;
+            break;
 
-  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_RX_READY:
+        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_RX_READY:
 
-    if (dataIndex < sizeof(dataBuffer)) {
-      dataBuffer[dataIndex++] = SERCOM3_I2C_ReadByte();
-    }
+            if (dataIndex < sizeof(dataBuffer)) {
+                dataBuffer[dataIndex++] = SERCOM3_I2C_ReadByte();
+            }
 
-    break;
+            break;
 
-  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_TX_READY: {
-    SERCOM3_I2C_WriteByte(encoder_angles[dataIndex++]);
-    break;
-  }
-
-  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_STOP_BIT_RECEIVED:
-    if (SERCOM3_I2C_TransferDirGet() == SERCOM_I2C_SLAVE_TRANSFER_DIR_WRITE) {
-      uint8_t start_byte = dataBuffer[0];
-      switch (start_byte) {
-      case I2C_SET_PWM:
-        set_pwm_dutycycle(dataBuffer + 1);
-        if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
+        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_TX_READY: {
+            SERCOM3_I2C_WriteByte(encoder_angles[dataIndex++]);
+            break;
         }
-        WDT_Clear();
-        break;
-      case I2C_STOP_GRIPPER:
-        WDT_Disable();
-        disable_servos();
-        TCC0_PWMStop();
-        TCC1_PWMStop();
-        ADC0_Disable();
-        gripper_state = STATE_IDLE;
-        break;
-      case I2C_START_GRIPPER:
-        TCC0_PWMStart();
-        TCC1_PWMStart();
-        ADC0_Enable();
-        RTC_Timer32Start();
-        RTC_Timer32CompareSet(RTC_COMPARE_VAL);
-        enable_servos();
-        gripper_state = STATE_GRIPPER_ACTIVE;
-        WDT_Enable();
-        break;
-      case I2C_RESET_MCU:
-        WDT_REGS->WDT_CLEAR = 0x0;
-      default:
-        break;
-      }
-      // printf("Message recieved\n");
-      // for (int i = 0; i < 7; i++) {
-      //     printf("%x\n", dataBuffer[i]);
-      // }
-    }
-    break;
-  default:
-    break;
-  }
 
-  return true;
+        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_STOP_BIT_RECEIVED:
+            if (SERCOM3_I2C_TransferDirGet() ==
+                SERCOM_I2C_SLAVE_TRANSFER_DIR_WRITE) {
+                uint8_t start_byte = dataBuffer[0];
+                switch (start_byte) {
+                    case I2C_SET_PWM:
+                        set_pwm_dutycycle(dataBuffer + 1);
+                        if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
+                        }
+                        WDT_Clear();
+                        break;
+                    case I2C_STOP_GRIPPER:
+                        WDT_Disable();
+                        disable_servos();
+                        TCC0_PWMStop();
+                        TCC1_PWMStop();
+                        ADC0_Disable();
+                        gripper_state = STATE_IDLE;
+                        break;
+                    case I2C_START_GRIPPER:
+                        TCC0_PWMStart();
+                        TCC1_PWMStart();
+                        ADC0_Enable();
+                        RTC_Timer32Start();
+                        RTC_Timer32CompareSet(RTC_COMPARE_VAL);
+                        enable_servos();
+                        gripper_state = STATE_GRIPPER_ACTIVE;
+                        WDT_Enable();
+                        break;
+                    case I2C_RESET_MCU:
+                        WDT_REGS->WDT_CLEAR = 0x0;
+                    default:
+                        break;
+                }
+                // printf("Message recieved\n");
+                // for (int i = 0; i < 7; i++) {
+                //     printf("%x\n", dataBuffer[i]);
+                // }
+            }
+            break;
+        default:
+            break;
+    }
+
+    return true;
 }
 
 void CAN_Recieve_Callback(uintptr_t context) {
-  xferContext = context;
+    xferContext = context;
 
-  status = CAN0_ErrorGet();
+    status = CAN0_ErrorGet();
 
-  if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
-      ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
-    switch (rx_messageID) {
-    case STOP_GRIPPER:
-      WDT_Disable();
+    if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
+        ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
+        switch (rx_messageID) {
+            case STOP_GRIPPER:
+                WDT_Disable();
 
-      disable_servos();
-      TCC0_PWMStop();
-      TCC1_PWMStop();
-      ADC0_Disable();
-      CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                          &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-      gripper_state = STATE_IDLE;
+                disable_servos();
+                TCC0_PWMStop();
+                TCC1_PWMStop();
+                ADC0_Disable();
+                CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
+                                    rx_message, &timestamp,
+                                    CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+                gripper_state = STATE_IDLE;
 
-      break;
-    case START_GRIPPER:
-      TCC0_PWMStart();
-      TCC1_PWMStart();
-      ADC0_Enable();
-      RTC_Timer32Start();
-      RTC_Timer32CompareSet(RTC_COMPARE_VAL);
+                break;
+            case START_GRIPPER:
+                TCC0_PWMStart();
+                TCC1_PWMStart();
+                ADC0_Enable();
+                RTC_Timer32Start();
+                RTC_Timer32CompareSet(RTC_COMPARE_VAL);
 
-      enable_servos();
-      memset(rx_message, 0x00, sizeof(rx_message));
-      CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                          &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-      gripper_state = STATE_GRIPPER_ACTIVE;
-      WDT_Enable();
-      break;
-    case SET_PWM:
-      set_pwm_dutycycle(rx_message);
-      if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
-        memset(rx_message, 0x00, sizeof(rx_message));
-        CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                            &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-        break;
-      }
-      if (CAN0_MessageTransmit(messageID, 6, encoder_angles,
-                               CAN_MODE_FD_WITHOUT_BRS,
-                               CAN_MSG_ATTR_TX_FIFO_DATA_FRAME) == false) {
-      }
-      /*printf("SET_PWM");*/
-      WDT_Clear();
-      break;
-    case RESET_MCU:
-      WDT_REGS->WDT_CLEAR = 0x0;
-      break;
-    default:
-      break;
+                enable_servos();
+                memset(rx_message, 0x00, sizeof(rx_message));
+                CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
+                                    rx_message, &timestamp,
+                                    CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+                gripper_state = STATE_GRIPPER_ACTIVE;
+                WDT_Enable();
+                break;
+            case SET_PWM:
+                set_pwm_dutycycle(rx_message);
+                if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
+                    memset(rx_message, 0x00, sizeof(rx_message));
+                    CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
+                                        rx_message, &timestamp,
+                                        CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+                    break;
+                }
+                if (CAN0_MessageTransmit(
+                        messageID, 6, encoder_angles, CAN_MODE_FD_WITHOUT_BRS,
+                        CAN_MSG_ATTR_TX_FIFO_DATA_FRAME) == false) {
+                }
+                /*printf("SET_PWM");*/
+                WDT_Clear();
+                break;
+            case RESET_MCU:
+                WDT_REGS->WDT_CLEAR = 0x0;
+                break;
+            default:
+                break;
+        }
+
+        /*printf(" New Message Received\r\n");*/
+        /*uint8_t length = rx_messageLength;*/
+        /*printf(*/
+        /*    " Message - Timestamp : 0x%x ID : 0x%x Length "*/
+        /*    ":0x%x",*/
+        /*    (unsigned int)timestamp, (unsigned int)rx_messageID,*/
+        /*    (unsigned int)rx_messageLength);*/
+        /*printf("Message : ");*/
+        /*while (length) {*/
+        /*    printf("0x%x ", rx_message[rx_messageLength - length--]);*/
+        /*}*/
     }
-
-    /*printf(" New Message Received\r\n");*/
-    /*uint8_t length = rx_messageLength;*/
-    /*printf(*/
-    /*    " Message - Timestamp : 0x%x ID : 0x%x Length "*/
-    /*    ":0x%x",*/
-    /*    (unsigned int)timestamp, (unsigned int)rx_messageID,*/
-    /*    (unsigned int)rx_messageLength);*/
-    /*printf("Message : ");*/
-    /*while (length) {*/
-    /*    printf("0x%x ", rx_message[rx_messageLength - length--]);*/
-    /*}*/
-  }
 }
 
 void CAN_Transmit_Callback(uintptr_t context) {
-  status = CAN0_ErrorGet();
+    status = CAN0_ErrorGet();
 
-  if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
-      ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
-    memset(rx_message, 0x00, sizeof(rx_message));
-    if (CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                            &timestamp, CAN_MSG_ATTR_RX_FIFO0,
-                            &msgFrameAttr) == false) {
+    if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
+        ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
+        memset(rx_message, 0x00, sizeof(rx_message));
+        if (CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                                &timestamp, CAN_MSG_ATTR_RX_FIFO0,
+                                &msgFrameAttr) == false) {
+        }
     }
-  }
 }
 
 // Only used for testing SERVOS
 void TCC_PeriodEventHandler(uint32_t status, uintptr_t context) {
-  /* duty cycle values */
-  static int8_t increment1 = 10;
-  static uint32_t duty1 = 0;
-  static uint32_t duty2 = 0;
-  static uint32_t duty3 = 0U;
+    /* duty cycle values */
+    static int8_t increment1 = 10;
+    static uint32_t duty1 = 0;
+    static uint32_t duty2 = 0;
+    static uint32_t duty3 = 0U;
 
-  TCC0_PWM24bitDutySet(1, duty1);
-  TCC1_PWM24bitDutySet(0, duty2);
-  TCC1_PWM24bitDutySet(1, duty3);
+    TCC0_PWM24bitDutySet(1, duty1);
+    TCC1_PWM24bitDutySet(0, duty2);
+    TCC1_PWM24bitDutySet(1, duty3);
 
-  duty1 += increment1;
-  duty2 += increment1;
-  duty3 += increment1;
+    duty1 += increment1;
+    duty2 += increment1;
+    duty3 += increment1;
 
-  if (duty1 > PWM_MAX) {
-    duty1 = PWM_MAX;
-    increment1 *= -1;
-  } else if (duty2 < PWM_MIN) {
-    duty1 = PWM_MIN;
-    increment1 *= -1;
-  }
-  if (duty2 > PWM_MAX) {
-    duty2 = PWM_MAX;
-    increment1 *= -1;
-  } else if (duty2 < PWM_MIN) {
-    duty2 = PWM_MIN;
-    increment1 *= -1;
-  }
-  if (duty3 > PWM_MAX) {
-    duty3 = PWM_MAX;
-    increment1 *= -1;
-  } else if (duty3 < PWM_MIN) {
-    duty3 = PWM_MIN;
-    increment1 *= -1;
-  }
+    if (duty1 > PWM_MAX) {
+        duty1 = PWM_MAX;
+        increment1 *= -1;
+    } else if (duty2 < PWM_MIN) {
+        duty1 = PWM_MIN;
+        increment1 *= -1;
+    }
+    if (duty2 > PWM_MAX) {
+        duty2 = PWM_MAX;
+        increment1 *= -1;
+    } else if (duty2 < PWM_MIN) {
+        duty2 = PWM_MIN;
+        increment1 *= -1;
+    }
+    if (duty3 > PWM_MAX) {
+        duty3 = PWM_MAX;
+        increment1 *= -1;
+    } else if (duty3 < PWM_MIN) {
+        duty3 = PWM_MIN;
+        increment1 *= -1;
+    }
 }
 
 void Dmac_Channel0_Callback(DMAC_TRANSFER_EVENT returned_evnt,
                             uintptr_t MyDmacContext) {
-  if (DMAC_TRANSFER_EVENT_COMPLETE == returned_evnt) {
-    bool overCurrent = false;
-    uint16_t input_voltage = 0;
-    for (int sample = 0; sample < TRANSFER_SIZE; sample++) {
-      input_voltage += adc_result_array[sample];
-      input_voltage = input_voltage >> 1; // Dividing by two
+    if (DMAC_TRANSFER_EVENT_COMPLETE == returned_evnt) {
+        bool overCurrent = false;
+        uint16_t input_voltage = 0;
+        for (int sample = 0; sample < TRANSFER_SIZE; sample++) {
+            input_voltage += adc_result_array[sample];
+            input_voltage = input_voltage >> 1;  // Dividing by two
 
-      // 2.5 V == 0 A
-      /*input_voltage =*/
-      /*    (float)(adc_result_array[sample] * ADC_VREF / 4095U - 2.5) /*/
-      /*    0.4;*/
+            // 2.5 V == 0 A
+            /*input_voltage =*/
+            /*    (float)(adc_result_array[sample] * ADC_VREF / 4095U - 2.5) /*/
+            /*    0.4;*/
 
-      /*printf(*/
-      /*    "ADC Count = 0x%03x, ADC Input Current = %d.%03d A "*/
-      /*    "\n\r",*/
-      /*    adc_result_array[sample], (int)input_voltage,*/
-      /*    (int)((input_voltage - (int)input_voltage) * 100.0));*/
+            /*printf(*/
+            /*    "ADC Count = 0x%03x, ADC Input Current = %d.%03d A "*/
+            /*    "\n\r",*/
+            /*    adc_result_array[sample], (int)input_voltage,*/
+            /*    (int)((input_voltage - (int)input_voltage) * 100.0));*/
+        }
+
+        if (input_voltage > VOLTAGE_THRESHOLD) {
+            overCurrent = true;
+        }
+        switch (servo_status) {
+            case SERVO_1:
+                if (overCurrent) {
+                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 27);
+                }
+                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN1;
+                servo_status = SERVO_2;
+                /*printf("SERVO2\n");*/
+                break;
+            case SERVO_2:
+                if (overCurrent) {
+                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 28);
+                }
+                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN4;
+                servo_status = SERVO_3;
+                /*printf("SERVO3\n");*/
+                break;
+            case SERVO_3:
+                if (overCurrent) {
+                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 0);
+                }
+                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN0;
+                servo_status = SERVO_1;
+                /*printf("SERVO1\n");*/
+                break;
+            default:
+                break;
+        }
+
+        DMAC_ChannelTransfer(
+            DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
+            (const void*)adc_result_array, sizeof(adc_result_array));
+    } else if (DMAC_TRANSFER_EVENT_ERROR == returned_evnt) {
+        DMAC_ChannelTransfer(
+            DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
+            (const void*)adc_result_array, sizeof(adc_result_array));
     }
-
-    if (input_voltage > VOLTAGE_THRESHOLD) {
-      overCurrent = true;
-    }
-    switch (servo_status) {
-    case SERVO_1:
-      if (overCurrent) {
-        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 27);
-      }
-      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN1;
-      servo_status = SERVO_2;
-      /*printf("SERVO2\n");*/
-      break;
-    case SERVO_2:
-      if (overCurrent) {
-        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 28);
-      }
-      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN4;
-      servo_status = SERVO_3;
-      /*printf("SERVO3\n");*/
-      break;
-    case SERVO_3:
-      if (overCurrent) {
-        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 0);
-      }
-      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN0;
-      servo_status = SERVO_1;
-      /*printf("SERVO1\n");*/
-      break;
-    default:
-      break;
-    }
-
-    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
-                         (const void *)adc_result_array,
-                         sizeof(adc_result_array));
-  } else if (DMAC_TRANSFER_EVENT_ERROR == returned_evnt) {
-    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
-                         (const void *)adc_result_array,
-                         sizeof(adc_result_array));
-  }
 }

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -34,7 +34,7 @@
 #define WRIST_ADDR 0x41
 #define GRIP_ADDR 0x42
 #define ANGLE_REGISTER 0xFE
-#define I2C_TIMOUT 10000
+#define I2C_TIMEOUT 10000
 #define NUM_ENCODERS 3
 
 #define TRANSFER_SIZE 16
@@ -186,7 +186,7 @@ static uint8_t encoder_read(uint8_t* data, uint8_t reg) {
     const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
                                                      GRIP_ADDR};
     uint8_t status = 0;
-    uint16_t timout = I2C_TIMOUT;
+    uint16_t timeout;
     uint16_t rawData[NUM_ENCODERS] = {0};
     uint8_t dataBuffer[2] = {0};
 
@@ -195,8 +195,9 @@ static uint8_t encoder_read(uint8_t* data, uint8_t reg) {
                                    2)) {
             return 1; 
         }
+        timeout = I2C_TIMEOUT;
         while (SERCOM1_I2C_IsBusy()) {
-            if (--timout == 0) {
+            if (--timeout == 0) {
                 status |= (1 << i);
                 break;
             }

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -229,34 +229,14 @@ static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds) {
 
     uint32_t tccValue =
         (shoulderDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
-
-    if (tccValue > PWM_MAX) {
-        TCC0_PWM24bitDutySet(3, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC0_PWM24bitDutySet(3, PWM_MIN);
-    } else {
-        TCC0_PWM24bitDutySet(3, tccValue);
-    }
+    TCC0_PWM24bitDutySet(3, tccValue);
 
     tccValue = (wristDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
-
-    if (tccValue > PWM_MAX) {
-        TCC1_PWM24bitDutySet(0, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC1_PWM24bitDutySet(0, PWM_MIN);
-    } else {
-        TCC1_PWM24bitDutySet(0, tccValue);
-    }
+    TCC1_PWM24bitDutySet(0, tccValue);
+    
 
     tccValue = (gripDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
-
-    if (tccValue > PWM_MAX) {
-        TCC1_PWM24bitDutySet(1, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC1_PWM24bitDutySet(1, PWM_MIN);
-    } else {
-        TCC1_PWM24bitDutySet(1, tccValue);
-    }
+    TCC1_PWM24bitDutySet(1, tccValue);
 }
 
 
@@ -312,7 +292,7 @@ bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                         WDT_Enable();
                         break;
                     case I2C_RESET_MCU:
-                        WDT_REGS->WDT_CLEAR = 0x0;
+                        WDT_REGS->WDT_CLEAR = 0;
                     default:
                         break;
                 }
@@ -339,7 +319,6 @@ void CAN_Recieve_Callback(uintptr_t context) {
         switch (rx_messageID) {
             case STOP_GRIPPER:
                 WDT_Disable();
-
                 disable_servos();
                 TCC0_PWMStop();
                 TCC1_PWMStop();
@@ -378,7 +357,6 @@ void CAN_Recieve_Callback(uintptr_t context) {
                         messageID, 6, encoder_angles, CAN_MODE_FD_WITHOUT_BRS,
                         CAN_MSG_ATTR_TX_FIFO_DATA_FRAME) == false) {
                 }
-                /*printf("SET_PWM");*/
                 WDT_Clear();
                 break;
             case RESET_MCU:

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -34,7 +34,7 @@
 #define WRIST_ADDR 0x41
 #define GRIP_ADDR 0x42
 #define ANGLE_REGISTER 0xFE
-#define I2C_TIMEOUT 10000
+#define I2C_TIMEOUT 100000
 #define NUM_ENCODERS 3
 
 #define TRANSFER_SIZE 16
@@ -191,11 +191,11 @@ static uint8_t encoder_read(uint8_t* data, uint8_t reg) {
     const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
                                                      GRIP_ADDR};
     uint8_t status = 0;
-    uint16_t timeout;
+    uint32_t timeout;
     uint16_t rawData[NUM_ENCODERS] = {0};
     uint8_t dataBuffer[2] = {0};
 
-    for (uint8_t i; i < NUM_ENCODERS; i++) {
+    for (uint8_t i = 0; i < NUM_ENCODERS; i++) {
         if (!SERCOM1_I2C_WriteRead(encoder_addresses[i], &reg, 1, dataBuffer,
                                    2)) {
             return 1;

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -5,23 +5,23 @@
  * Created on January 19, 2025, 2:50 PM
  */
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include "adc0.h"
 #include "can1.h"
 #include "can_common.h"
 #include "clock.h"
 #include "dma.h"
-#include "i2c.h"  // I2C client backup
+#include "i2c.h" // I2C client backup
 #include "pm.h"
 #include "rtc.h"
 #include "sam.h"
 #include "samc21e17a.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 /*#include "sercom0_i2c.h"*/
-#include "sercom1_i2c.h"  // Encoder i2c
+#include "sercom1_i2c.h" // Encoder i2c
 #include "system_init.h"
 #include "tcc.h"
 #include "tcc0.h"
@@ -39,7 +39,7 @@
 
 #define TRANSFER_SIZE 16
 #define ADC_VREF 5.0f
-#define CURRENT_TRESHOLD 2.7f  // 1 A
+#define CURRENT_TRESHOLD 2.7f // 1 A
 #define VOLTAGE_THRESHOLD 2048
 #define RTC_COMPARE_VAL 50
 
@@ -48,36 +48,36 @@ uint8_t Can0MessageRAM[CAN0_MESSAGE_RAM_CONFIG_SIZE]
 
 /* Application's state machine enum */
 typedef enum {
-    STATE_IDLE,
-    STATE_GRIPPER_ACTIVE,
+  STATE_IDLE,
+  STATE_GRIPPER_ACTIVE,
 } STATES;
 
 typedef enum {
-    STATE_CAN_RECEIVE,
-    STATE_CAN_TRANSMIT,
+  STATE_CAN_RECEIVE,
+  STATE_CAN_TRANSMIT,
 } CAN_STATES;
 
 // CAN FD RECIEVE ID table
 typedef enum {
-    STOP_GRIPPER = 0x469,
-    START_GRIPPER,
-    SET_PWM,
-    RESET_MCU,
+  STOP_GRIPPER = 0x469,
+  START_GRIPPER,
+  SET_PWM,
+  RESET_MCU,
 } CAN_RECEIVE_ID;
 
 // I2C RECIEVE START BYTE table
 typedef enum {
-    I2C_SET_PWM,
-    I2C_STOP_GRIPPER,
-    I2C_START_GRIPPER,
-    I2C_RESET_MCU,
+  I2C_SET_PWM,
+  I2C_STOP_GRIPPER,
+  I2C_START_GRIPPER,
+  I2C_RESET_MCU,
 } I2C_STARTBYTE_ID;
 
 /* Servo pins enum for ADC reading */
 typedef enum {
-    SERVO_1,
-    SERVO_2,
-    SERVO_3,
+  SERVO_1,
+  SERVO_2,
+  SERVO_3,
 } SERVO_ADC_PINS;
 
 /*CAN*/
@@ -98,9 +98,8 @@ uint16_t adc_result_array[TRANSFER_SIZE];
 volatile static STATES gripper_state = STATE_IDLE;
 static uint8_t encoder_angles[7] = {0};
 
-
-static uint8_t encoder_read(uint8_t* data, uint8_t reg);
-static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds);
+static uint8_t encoder_read(uint8_t *data, uint8_t reg);
+static void set_pwm_dutycycle(uint8_t *dutyCycleMicroSeconds);
 
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle);
@@ -111,415 +110,403 @@ void Dmac_Channel0_Callback(DMAC_TRANSFER_EVENT returned_evnt,
                             uintptr_t MyDmacContext);
 
 int main(void) {
-    NVMCTRL_REGS->NVMCTRL_CTRLB = NVMCTRL_CTRLB_RWS(3);
-    PM_Initialize();
-    PIN_Initialize();
-    CLOCK_Initialize();
-    NVMCTRL_Initialize();
-    TCC1_PWMInitialize();
-    TCC0_PWMInitialize();
-    CAN0_Initialize();
-    // SERCOM0_I2C_Initialize();  // I2C 3
-    SERCOM1_I2C_Initialize();  // I2C 2
+  NVMCTRL_REGS->NVMCTRL_CTRLB = NVMCTRL_CTRLB_RWS(3);
+  PM_Initialize();
+  PIN_Initialize();
+  CLOCK_Initialize();
+  NVMCTRL_Initialize();
+  TCC1_PWMInitialize();
+  TCC0_PWMInitialize();
+  CAN0_Initialize();
+  // SERCOM0_I2C_Initialize();  // I2C 3
+  SERCOM1_I2C_Initialize(); // I2C 2
 
-    SERCOM0_USART_Initialize();  // USART for Debugging
+  SERCOM0_USART_Initialize(); // USART for Debugging
 
-    /*SERCOM3_SLAVE_I2C_Initialize();*/
+  SERCOM3_SLAVE_I2C_Initialize();
 
-    EVSYS_Initialize();
-    ADC0_Initialize();
-    DMAC_Initialize();
-    RTC_Initialize();
+  EVSYS_Initialize();
+  ADC0_Initialize();
+  DMAC_Initialize();
+  RTC_Initialize();
 
-    NVIC_Initialize();
+  NVIC_Initialize();
 
-    /* Peripherals should be disabled by default and will be enabled
-     Enable if testing without CAN or I2C */
-    // TCC1_PWMStart();
-    // TCC0_PWMStart();
-    // ADC0_Enable();
-    // RTC_Timer32Start();
-    // RTC_Timer32CompareSet(RTC_COMPARE_VAL);
+  /* Peripherals should be disabled by default and will be enabled
+   Enable if testing without CAN or I2C */
+  // TCC1_PWMStart();
+  // TCC0_PWMStart();
+  // ADC0_Enable();
+  // RTC_Timer32Start();
+  // RTC_Timer32CompareSet(RTC_COMPARE_VAL);
 
-    CAN0_MessageRAMConfigSet(Can0MessageRAM);
+  CAN0_MessageRAMConfigSet(Can0MessageRAM);
 
-    // SERCOM3_I2C_CallbackRegister(SERCOM_I2C_Callback, 0);
+  // SERCOM3_I2C_CallbackRegister(SERCOM_I2C_Callback, 0);
 
-    // TCC0_PWMCallbackRegister(TCC_PeriodEventHandler, (uintptr_t)NULL);
+  // TCC0_PWMCallbackRegister(TCC_PeriodEventHandler, (uintptr_t)NULL);
 
-    DMAC_ChannelCallbackRegister(DMAC_CHANNEL_0, Dmac_Channel0_Callback,
-                                 (uintptr_t)&myAppObj);
-    CAN0_RxCallbackRegister(CAN_Recieve_Callback, (uintptr_t)STATE_CAN_RECEIVE,
-                            CAN_MSG_ATTR_RX_FIFO0);
-    CAN0_TxCallbackRegister(CAN_Transmit_Callback,
-                            (uintptr_t)STATE_CAN_TRANSMIT);
+  DMAC_ChannelCallbackRegister(DMAC_CHANNEL_0, Dmac_Channel0_Callback,
+                               (uintptr_t)&myAppObj);
+  CAN0_RxCallbackRegister(CAN_Recieve_Callback, (uintptr_t)STATE_CAN_RECEIVE,
+                          CAN_MSG_ATTR_RX_FIFO0);
+  CAN0_TxCallbackRegister(CAN_Transmit_Callback, (uintptr_t)STATE_CAN_TRANSMIT);
 
-    memset(rx_message, 0x00, sizeof(rx_message));
-    // Enabling CAN recieve interrupt for fifo0
-    CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                        &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+  memset(rx_message, 0x00, sizeof(rx_message));
+  // Enabling CAN recieve interrupt for fifo0
+  CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message, &timestamp,
+                      CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
 
-    // Servo Enable
-    /*PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);*/
-
-    /*printf("Initialize complete\n");*/
-    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
-                         (const void*)adc_result_array,
-                         sizeof(adc_result_array));
-    while (true) {
-        switch (gripper_state) {
-            case STATE_IDLE:
-                PM_IdleModeEnter();
-                break;
-            case STATE_GRIPPER_ACTIVE:
-                break;
-            default:
-                break;
-        }
+  // Servo Enable
+  /*PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);*/
+  /*printf("Initialize complete\n");*/
+  DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
+                       (const void *)adc_result_array,
+                       sizeof(adc_result_array));
+  while (true) {
+    switch (gripper_state) {
+    case STATE_IDLE:
+      PM_IdleModeEnter();
+      break;
+    case STATE_GRIPPER_ACTIVE:
+      break;
+    default:
+      break;
     }
+  }
 
-    /* Execution should not come here during normal operation */
-    return EXIT_FAILURE;
+  return EXIT_FAILURE;
 }
 
-static uint8_t encoder_read(uint8_t* data, uint8_t reg) {
-    const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
-                                                     GRIP_ADDR};
-    uint8_t status = 0;
-    uint16_t timeout;
-    uint16_t rawData[NUM_ENCODERS] = {0};
-    uint8_t dataBuffer[2] = {0};
+static uint8_t encoder_read(uint8_t *data, uint8_t reg) {
+  const uint8_t encoder_addresses[NUM_ENCODERS] = {SHOULDER_ADDR, WRIST_ADDR,
+                                                   GRIP_ADDR};
+  uint8_t status = 0;
+  uint16_t timeout;
+  uint16_t rawData[NUM_ENCODERS] = {0};
+  uint8_t dataBuffer[2] = {0};
 
-    for (uint8_t i; i < NUM_ENCODERS; i++) {
-        if (!SERCOM1_I2C_WriteRead(encoder_addresses[i], &reg, 1, dataBuffer,
-                                   2)) {
-            return 1; 
-        }
-        timeout = I2C_TIMEOUT;
-        while (SERCOM1_I2C_IsBusy()) {
-            if (--timeout == 0) {
-                status |= (1 << i);
-                break;
-            }
-        }
-        rawData[i] = (dataBuffer[0] << 6) | (dataBuffer[1] & 0x3F);
+  for (uint8_t i; i < NUM_ENCODERS; i++) {
+    if (!SERCOM1_I2C_WriteRead(encoder_addresses[i], &reg, 1, dataBuffer, 2)) {
+      return 1;
     }
-
-    for (int i = 1; i < NUM_ENCODERS; i++) {
-        data[2 * i] = rawData[i] >> 8;
-        data[2 * i + 1] = rawData[i] & 0xFF;
+    timeout = I2C_TIMEOUT;
+    while (SERCOM1_I2C_IsBusy()) {
+      if (--timeout == 0) {
+        status |= (1 << i);
+        break;
+      }
     }
-    data[6] = status;
+    rawData[i] = (dataBuffer[0] << 6) | (dataBuffer[1] & 0x3F);
+  }
 
-    return 0;
+  for (int i = 1; i < NUM_ENCODERS; i++) {
+    data[2 * i] = rawData[i] >> 8;
+    data[2 * i + 1] = rawData[i] & 0xFF;
+  }
+  data[6] = status;
+
+  return 0;
 }
 
-static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds) {
-    uint16_t shoulderDuty =
-        (dutyCycleMicroSeconds[0] << 8) | dutyCycleMicroSeconds[1];
-    uint16_t wristDuty =
-        (dutyCycleMicroSeconds[2] << 8) | dutyCycleMicroSeconds[3];
-    uint16_t gripDuty =
-        (dutyCycleMicroSeconds[4] << 8) | dutyCycleMicroSeconds[5];
+static void set_pwm_dutycycle(uint8_t *dutyCycleMicroSeconds) {
+  uint16_t shoulderDuty =
+      (dutyCycleMicroSeconds[0] << 8) | dutyCycleMicroSeconds[1];
+  uint16_t wristDuty =
+      (dutyCycleMicroSeconds[2] << 8) | dutyCycleMicroSeconds[3];
+  uint16_t gripDuty =
+      (dutyCycleMicroSeconds[4] << 8) | dutyCycleMicroSeconds[5];
 
-    // SHOULDER
-    uint32_t tccValue =
-        (shoulderDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
+  uint32_t tccValue =
+      (shoulderDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
 
-    if (tccValue > PWM_MAX) {
-        TCC0_PWM24bitDutySet(3, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC0_PWM24bitDutySet(3, PWM_MIN);
-    } else {
-        TCC0_PWM24bitDutySet(3, tccValue);
-    }
+  if (tccValue > PWM_MAX) {
+    TCC0_PWM24bitDutySet(3, PWM_MAX);
+  } else if (tccValue < PWM_MIN) {
+    TCC0_PWM24bitDutySet(3, PWM_MIN);
+  } else {
+    TCC0_PWM24bitDutySet(3, tccValue);
+  }
 
-    // WRIST
-    tccValue = (wristDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
-    if (tccValue > PWM_MAX) {
-        TCC1_PWM24bitDutySet(0, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC1_PWM24bitDutySet(0, PWM_MIN);
-    } else {
-        TCC1_PWM24bitDutySet(0, tccValue);
-    }
+  tccValue = (wristDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
 
-    // GRIP
-    tccValue = (gripDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
-    if (tccValue > PWM_MAX) {
-        TCC1_PWM24bitDutySet(1, PWM_MAX);
-    } else if (tccValue < PWM_MIN) {
-        TCC1_PWM24bitDutySet(1, PWM_MIN);
-    } else {
-        TCC1_PWM24bitDutySet(1, tccValue);
-    }
+  if (tccValue > PWM_MAX) {
+    TCC1_PWM24bitDutySet(0, PWM_MAX);
+  } else if (tccValue < PWM_MIN) {
+    TCC1_PWM24bitDutySet(0, PWM_MIN);
+  } else {
+    TCC1_PWM24bitDutySet(0, tccValue);
+  }
+
+  tccValue = (gripDuty * (TCC_PERIOD + 1)) / PWM_PERIOD_MICROSECONDS;
+
+  if (tccValue > PWM_MAX) {
+    TCC1_PWM24bitDutySet(1, PWM_MAX);
+  } else if (tccValue < PWM_MIN) {
+    TCC1_PWM24bitDutySet(1, PWM_MIN);
+  } else {
+    TCC1_PWM24bitDutySet(1, tccValue);
+  }
+}
+
+static inline void enable_servos() {
+  PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);
+}
+static inline void disable_servos() {
+
+  PORT_REGS->GROUP[0].PORT_OUTCLR = (1 << 0) | (1 << 27) | (1 << 28);
 }
 
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle) {
-    static uint8_t dataBuffer[7];
-    static uint8_t dataIndex = 0;
+  static uint8_t dataBuffer[7];
+  static uint8_t dataIndex = 0;
 
-    switch (event) {
-        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_ADDR_MATCH:
-            dataIndex = 0;
-            break;
+  switch (event) {
+  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_ADDR_MATCH:
+    dataIndex = 0;
+    break;
 
-        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_RX_READY:
+  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_RX_READY:
 
-            if (dataIndex < sizeof(dataBuffer)) {
-                dataBuffer[dataIndex++] = SERCOM3_I2C_ReadByte();
-            }
-
-            break;
-
-        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_TX_READY: {
-            SERCOM3_I2C_WriteByte(encoder_angles[dataIndex++]);
-            break;
-        }
-
-        case SERCOM_I2C_SLAVE_TRANSFER_EVENT_STOP_BIT_RECEIVED:
-            if (SERCOM3_I2C_TransferDirGet() ==
-                SERCOM_I2C_SLAVE_TRANSFER_DIR_WRITE) {
-                uint8_t start_byte = dataBuffer[0];
-                switch (start_byte) {
-                    case I2C_SET_PWM:
-                        set_pwm_dutycycle(dataBuffer + 1);
-                        if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
-                        }
-                        WDT_Clear();
-                        break;
-                    case I2C_STOP_GRIPPER:
-                        WDT_Disable();
-                        // Turn off sevo enable pin
-                        PORT_REGS->GROUP[0].PORT_OUTCLR =
-                            (1 << 0) | (1 << 27) | (1 << 28);
-                        TCC0_PWMStop();
-                        TCC1_PWMStop();
-                        ADC0_Disable();
-                        gripper_state = STATE_IDLE;
-                        /*PM_IdleModeEnter();*/
-                        break;
-                    case I2C_START_GRIPPER:
-                        TCC0_PWMStart();
-                        TCC1_PWMStart();
-                        ADC0_Enable();
-                        RTC_Timer32Start();
-                        RTC_Timer32CompareSet(RTC_COMPARE_VAL);
-                        // Turn on servo enable pin
-                        PORT_REGS->GROUP[0].PORT_OUTSET =
-                            (1 << 0) | (1 << 27) | (1 << 28);
-                        gripper_state = STATE_GRIPPER_ACTIVE;
-                        WDT_Enable();
-                        break;
-                    case I2C_RESET_MCU:
-                        WDT_REGS->WDT_CLEAR = 0x0;
-                    default:
-                        break;
-                }
-                // printf("Message recieved\n");
-                // for (int i = 0; i < 7; i++) {
-                //     printf("%x\n", dataBuffer[i]);
-                // }
-            }
-            break;
-        default:
-            break;
+    if (dataIndex < sizeof(dataBuffer)) {
+      dataBuffer[dataIndex++] = SERCOM3_I2C_ReadByte();
     }
 
-    return true;
+    break;
+
+  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_TX_READY: {
+    SERCOM3_I2C_WriteByte(encoder_angles[dataIndex++]);
+    break;
+  }
+
+  case SERCOM_I2C_SLAVE_TRANSFER_EVENT_STOP_BIT_RECEIVED:
+    if (SERCOM3_I2C_TransferDirGet() == SERCOM_I2C_SLAVE_TRANSFER_DIR_WRITE) {
+      uint8_t start_byte = dataBuffer[0];
+      switch (start_byte) {
+      case I2C_SET_PWM:
+        set_pwm_dutycycle(dataBuffer + 1);
+        if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
+        }
+        WDT_Clear();
+        break;
+      case I2C_STOP_GRIPPER:
+        WDT_Disable();
+        disable_servos();
+        TCC0_PWMStop();
+        TCC1_PWMStop();
+        ADC0_Disable();
+        gripper_state = STATE_IDLE;
+        break;
+      case I2C_START_GRIPPER:
+        TCC0_PWMStart();
+        TCC1_PWMStart();
+        ADC0_Enable();
+        RTC_Timer32Start();
+        RTC_Timer32CompareSet(RTC_COMPARE_VAL);
+        enable_servos();
+        gripper_state = STATE_GRIPPER_ACTIVE;
+        WDT_Enable();
+        break;
+      case I2C_RESET_MCU:
+        WDT_REGS->WDT_CLEAR = 0x0;
+      default:
+        break;
+      }
+      // printf("Message recieved\n");
+      // for (int i = 0; i < 7; i++) {
+      //     printf("%x\n", dataBuffer[i]);
+      // }
+    }
+    break;
+  default:
+    break;
+  }
+
+  return true;
 }
 
 void CAN_Recieve_Callback(uintptr_t context) {
-    xferContext = context;
+  xferContext = context;
 
-    status = CAN0_ErrorGet();
+  status = CAN0_ErrorGet();
 
-    if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
-        ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
-        switch (rx_messageID) {
-            case STOP_GRIPPER:
-                WDT_Disable();
+  if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
+      ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
+    switch (rx_messageID) {
+    case STOP_GRIPPER:
+      WDT_Disable();
 
-                // Turn off servo enable pins
-                PORT_REGS->GROUP[0].PORT_OUTCLR =
-                    (1 << 0) | (1 << 27) | (1 << 28);
+      disable_servos();
+      TCC0_PWMStop();
+      TCC1_PWMStop();
+      ADC0_Disable();
+      CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                          &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+      gripper_state = STATE_IDLE;
 
-                TCC0_PWMStop();
-                TCC1_PWMStop();
-                ADC0_Disable();
-                CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
-                                    rx_message, &timestamp,
-                                    CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-                gripper_state = STATE_IDLE;
+      break;
+    case START_GRIPPER:
+      TCC0_PWMStart();
+      TCC1_PWMStart();
+      ADC0_Enable();
+      RTC_Timer32Start();
+      RTC_Timer32CompareSet(RTC_COMPARE_VAL);
 
-                break;
-            case START_GRIPPER:
-                TCC0_PWMStart();
-                TCC1_PWMStart();
-                ADC0_Enable();
-                RTC_Timer32Start();
-                RTC_Timer32CompareSet(RTC_COMPARE_VAL);
-
-                // Turn on servo enable pins
-                PORT_REGS->GROUP[0].PORT_OUTSET =
-                    (1 << 0) | (1 << 27) | (1 << 28);
-
-                memset(rx_message, 0x00, sizeof(rx_message));
-                CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
-                                    rx_message, &timestamp,
-                                    CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-                gripper_state = STATE_GRIPPER_ACTIVE;
-                WDT_Enable();
-                break;
-            case SET_PWM:
-                set_pwm_dutycycle(rx_message);
-                if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
-                    memset(rx_message, 0x00, sizeof(rx_message));
-                    CAN0_MessageReceive(&rx_messageID, &rx_messageLength,
-                                        rx_message, &timestamp,
-                                        CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
-                    break;
-                }
-                if (CAN0_MessageTransmit(
-                        messageID, 6, encoder_angles, CAN_MODE_FD_WITHOUT_BRS,
-                        CAN_MSG_ATTR_TX_FIFO_DATA_FRAME) == false) {
-                }
-                /*printf("SET_PWM");*/
-                WDT_Clear();
-                break;
-            case RESET_MCU:
-                WDT_REGS->WDT_CLEAR = 0x0;
-                break;
-            default:
-                break;
-        }
-
-        /*printf(" New Message Received\r\n");*/
-        /*uint8_t length = rx_messageLength;*/
-        /*printf(*/
-        /*    " Message - Timestamp : 0x%x ID : 0x%x Length "*/
-        /*    ":0x%x",*/
-        /*    (unsigned int)timestamp, (unsigned int)rx_messageID,*/
-        /*    (unsigned int)rx_messageLength);*/
-        /*printf("Message : ");*/
-        /*while (length) {*/
-        /*    printf("0x%x ", rx_message[rx_messageLength - length--]);*/
-        /*}*/
+      enable_servos();
+      memset(rx_message, 0x00, sizeof(rx_message));
+      CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                          &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+      gripper_state = STATE_GRIPPER_ACTIVE;
+      WDT_Enable();
+      break;
+    case SET_PWM:
+      set_pwm_dutycycle(rx_message);
+      if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
+        memset(rx_message, 0x00, sizeof(rx_message));
+        CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                            &timestamp, CAN_MSG_ATTR_RX_FIFO0, &msgFrameAttr);
+        break;
+      }
+      if (CAN0_MessageTransmit(messageID, 6, encoder_angles,
+                               CAN_MODE_FD_WITHOUT_BRS,
+                               CAN_MSG_ATTR_TX_FIFO_DATA_FRAME) == false) {
+      }
+      /*printf("SET_PWM");*/
+      WDT_Clear();
+      break;
+    case RESET_MCU:
+      WDT_REGS->WDT_CLEAR = 0x0;
+      break;
+    default:
+      break;
     }
+
+    /*printf(" New Message Received\r\n");*/
+    /*uint8_t length = rx_messageLength;*/
+    /*printf(*/
+    /*    " Message - Timestamp : 0x%x ID : 0x%x Length "*/
+    /*    ":0x%x",*/
+    /*    (unsigned int)timestamp, (unsigned int)rx_messageID,*/
+    /*    (unsigned int)rx_messageLength);*/
+    /*printf("Message : ");*/
+    /*while (length) {*/
+    /*    printf("0x%x ", rx_message[rx_messageLength - length--]);*/
+    /*}*/
+  }
 }
 
 void CAN_Transmit_Callback(uintptr_t context) {
-    status = CAN0_ErrorGet();
+  status = CAN0_ErrorGet();
 
-    if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
-        ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
-        memset(rx_message, 0x00, sizeof(rx_message));
-        if (CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
-                                &timestamp, CAN_MSG_ATTR_RX_FIFO0,
-                                &msgFrameAttr) == false) {
-        }
+  if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||
+      ((status & CAN_PSR_LEC_Msk) == CAN_ERROR_LEC_NC)) {
+    memset(rx_message, 0x00, sizeof(rx_message));
+    if (CAN0_MessageReceive(&rx_messageID, &rx_messageLength, rx_message,
+                            &timestamp, CAN_MSG_ATTR_RX_FIFO0,
+                            &msgFrameAttr) == false) {
     }
+  }
 }
 
 // Only used for testing SERVOS
 void TCC_PeriodEventHandler(uint32_t status, uintptr_t context) {
-    /* duty cycle values */
-    static int8_t increment1 = 10;
-    static uint32_t duty1 = 0;
-    static uint32_t duty2 = 0;
-    static uint32_t duty3 = 0U;
+  /* duty cycle values */
+  static int8_t increment1 = 10;
+  static uint32_t duty1 = 0;
+  static uint32_t duty2 = 0;
+  static uint32_t duty3 = 0U;
 
-    TCC0_PWM24bitDutySet(1, duty1);
-    TCC1_PWM24bitDutySet(0, duty2);
-    TCC1_PWM24bitDutySet(1, duty3);
+  TCC0_PWM24bitDutySet(1, duty1);
+  TCC1_PWM24bitDutySet(0, duty2);
+  TCC1_PWM24bitDutySet(1, duty3);
 
-    duty1 += increment1;
-    duty2 += increment1;
-    duty3 += increment1;
+  duty1 += increment1;
+  duty2 += increment1;
+  duty3 += increment1;
 
-    if (duty1 > PWM_MAX) {
-        duty1 = PWM_MAX;
-        increment1 *= -1;
-    } else if (duty2 < PWM_MIN) {
-        duty1 = PWM_MIN;
-        increment1 *= -1;
-    }
-    if (duty2 > PWM_MAX) {
-        duty2 = PWM_MAX;
-        increment1 *= -1;
-    } else if (duty2 < PWM_MIN) {
-        duty2 = PWM_MIN;
-        increment1 *= -1;
-    }
-    if (duty3 > PWM_MAX) {
-        duty3 = PWM_MAX;
-        increment1 *= -1;
-    } else if (duty3 < PWM_MIN) {
-        duty3 = PWM_MIN;
-        increment1 *= -1;
-    }
+  if (duty1 > PWM_MAX) {
+    duty1 = PWM_MAX;
+    increment1 *= -1;
+  } else if (duty2 < PWM_MIN) {
+    duty1 = PWM_MIN;
+    increment1 *= -1;
+  }
+  if (duty2 > PWM_MAX) {
+    duty2 = PWM_MAX;
+    increment1 *= -1;
+  } else if (duty2 < PWM_MIN) {
+    duty2 = PWM_MIN;
+    increment1 *= -1;
+  }
+  if (duty3 > PWM_MAX) {
+    duty3 = PWM_MAX;
+    increment1 *= -1;
+  } else if (duty3 < PWM_MIN) {
+    duty3 = PWM_MIN;
+    increment1 *= -1;
+  }
 }
 
 void Dmac_Channel0_Callback(DMAC_TRANSFER_EVENT returned_evnt,
                             uintptr_t MyDmacContext) {
-    if (DMAC_TRANSFER_EVENT_COMPLETE == returned_evnt) {
-        bool overCurrent = false;
-        uint16_t input_voltage = 0;
-        for (int sample = 0; sample < TRANSFER_SIZE; sample++) {
-            input_voltage += adc_result_array[sample];
-            input_voltage = input_voltage >> 1;  // Dividing by two
+  if (DMAC_TRANSFER_EVENT_COMPLETE == returned_evnt) {
+    bool overCurrent = false;
+    uint16_t input_voltage = 0;
+    for (int sample = 0; sample < TRANSFER_SIZE; sample++) {
+      input_voltage += adc_result_array[sample];
+      input_voltage = input_voltage >> 1; // Dividing by two
 
-            // 2.5 V == 0 A
-            /*input_voltage =*/
-            /*    (float)(adc_result_array[sample] * ADC_VREF / 4095U - 2.5) /*/
-            /*    0.4;*/
+      // 2.5 V == 0 A
+      /*input_voltage =*/
+      /*    (float)(adc_result_array[sample] * ADC_VREF / 4095U - 2.5) /*/
+      /*    0.4;*/
 
-            /*printf(*/
-            /*    "ADC Count = 0x%03x, ADC Input Current = %d.%03d A "*/
-            /*    "\n\r",*/
-            /*    adc_result_array[sample], (int)input_voltage,*/
-            /*    (int)((input_voltage - (int)input_voltage) * 100.0));*/
-        }
-
-        if (input_voltage > VOLTAGE_THRESHOLD) {
-            overCurrent = true;
-        }
-        switch (servo_status) {
-            case SERVO_1:
-                if (overCurrent) {
-                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 27);
-                }
-                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN1;
-                servo_status = SERVO_2;
-                /*printf("SERVO2\n");*/
-                break;
-            case SERVO_2:
-                if (overCurrent) {
-                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 28);
-                }
-                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN4;
-                servo_status = SERVO_3;
-                /*printf("SERVO3\n");*/
-                break;
-            case SERVO_3:
-                if (overCurrent) {
-                    PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 0);
-                }
-                ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN0;
-                servo_status = SERVO_1;
-                /*printf("SERVO1\n");*/
-                break;
-            default:
-                break;
-        }
-
-        DMAC_ChannelTransfer(
-            DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
-            (const void*)adc_result_array, sizeof(adc_result_array));
-    } else if (DMAC_TRANSFER_EVENT_ERROR == returned_evnt) {
-        DMAC_ChannelTransfer(
-            DMAC_CHANNEL_0, (const void*)&ADC0_REGS->ADC_RESULT,
-            (const void*)adc_result_array, sizeof(adc_result_array));
+      /*printf(*/
+      /*    "ADC Count = 0x%03x, ADC Input Current = %d.%03d A "*/
+      /*    "\n\r",*/
+      /*    adc_result_array[sample], (int)input_voltage,*/
+      /*    (int)((input_voltage - (int)input_voltage) * 100.0));*/
     }
+
+    if (input_voltage > VOLTAGE_THRESHOLD) {
+      overCurrent = true;
+    }
+    switch (servo_status) {
+    case SERVO_1:
+      if (overCurrent) {
+        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 27);
+      }
+      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN1;
+      servo_status = SERVO_2;
+      /*printf("SERVO2\n");*/
+      break;
+    case SERVO_2:
+      if (overCurrent) {
+        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 28);
+      }
+      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN4;
+      servo_status = SERVO_3;
+      /*printf("SERVO3\n");*/
+      break;
+    case SERVO_3:
+      if (overCurrent) {
+        PORT_REGS->GROUP[0].PORT_OUTCLR |= (1 << 0);
+      }
+      ADC0_REGS->ADC_INPUTCTRL = ADC_POSINPUT_AIN0;
+      servo_status = SERVO_1;
+      /*printf("SERVO1\n");*/
+      break;
+    default:
+      break;
+    }
+
+    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
+                         (const void *)adc_result_array,
+                         sizeof(adc_result_array));
+  } else if (DMAC_TRANSFER_EVENT_ERROR == returned_evnt) {
+    DMAC_ChannelTransfer(DMAC_CHANNEL_0, (const void *)&ADC0_REGS->ADC_RESULT,
+                         (const void *)adc_result_array,
+                         sizeof(adc_result_array));
+  }
 }

--- a/gripper_17.X/src/main.c
+++ b/gripper_17.X/src/main.c
@@ -101,6 +101,14 @@ static uint8_t encoder_angles[7] = {0};
 static uint8_t encoder_read(uint8_t* data, uint8_t reg);
 static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds);
 
+
+static inline void enable_servos() {
+    PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);
+}
+static inline void disable_servos() {
+    PORT_REGS->GROUP[0].PORT_OUTCLR = (1 << 0) | (1 << 27) | (1 << 28);
+}
+
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle);
 void CAN_Recieve_Callback(uintptr_t context);
@@ -251,12 +259,6 @@ static void set_pwm_dutycycle(uint8_t* dutyCycleMicroSeconds) {
     }
 }
 
-static inline void enable_servos() {
-    PORT_REGS->GROUP[0].PORT_OUTSET = (1 << 0) | (1 << 27) | (1 << 28);
-}
-static inline void disable_servos() {
-    PORT_REGS->GROUP[0].PORT_OUTCLR = (1 << 0) | (1 << 27) | (1 << 28);
-}
 
 bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                          uintptr_t contextHandle) {
@@ -288,8 +290,7 @@ bool SERCOM_I2C_Callback(SERCOM_I2C_SLAVE_TRANSFER_EVENT event,
                 switch (start_byte) {
                     case I2C_SET_PWM:
                         set_pwm_dutycycle(dataBuffer + 1);
-                        if (encoder_read(encoder_angles, ANGLE_REGISTER)) {
-                        }
+                        encoder_read(encoder_angles, ANGLE_REGISTER); 
                         WDT_Clear();
                         break;
                     case I2C_STOP_GRIPPER:
@@ -402,6 +403,7 @@ void CAN_Recieve_Callback(uintptr_t context) {
 }
 
 void CAN_Transmit_Callback(uintptr_t context) {
+
     status = CAN0_ErrorGet();
 
     if (((status & CAN_PSR_LEC_Msk) == CAN_ERROR_NONE) ||

--- a/pwm_generator.X/nbproject/Makefile-genesis.properties
+++ b/pwm_generator.X/nbproject/Makefile-genesis.properties
@@ -1,11 +1,11 @@
 #
-#Fri Mar 21 15:23:16 CET 2025
+#Sat Apr 12 11:54:21 CEST 2025
 default.languagetoolchain.version=4.50
 default.Pack.dfplocation=/opt/microchip/mplabx/v6.20/packs/Microchip/SAMC21_DFP/3.8.119
 conf.ids=default
 default.languagetoolchain.dir=/opt/microchip/xc32/v4.50/bin
 default.com-microchip-mplab-nbide-toolchain-xc32-XC32LanguageToolchain.md5=1eaf555a844840d91945cb14109201c3
-host.id=2jbv-wc6h-6s
+host.id=1ajf-v1xd-vo
 default.platformTool.md5=null
 configurations-xml=44c45b839af1b9cabbc3ba4b5c5f1a9a
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=f612087c95360c842296d189edfe3321


### PR DESCRIPTION
I2C timeout no longer causes watchdog timer reset.

This means that if one encoder is lost we can now get the reading from the others.

When reading from the encoder, there is now an option to read a 4th byte containing the statues for the encoders.
If one of the three last bits in the status bytes are high it will indicate a timeout on one of the encoders.